### PR TITLE
Use user-selected monospace font

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -342,13 +342,13 @@ input[type="submit"], input[type="reset"] {
 /* テキストボックスで等幅フォントを使用 */
 
 input[type="text"] {
-  font-family: "Osaka-Mono", "MS Gothic", sans-serif;
+  font-family: monospace;
   font-size: 100%;
 }
 
 textarea.wiki-edit {
   font-size: 14px;
-  font-family: "Osaka-Mono", "MS Gothic", sans-serif;
+  font-family: monospace;
   letter-spacing: normal;
   line-height: 130%;
 }


### PR DESCRIPTION
デフォルトではＭＳ ゴシックかOsakaで決め打ちになっているので、個人が「見やすい」フォントをブラウザのmonospaceに設定していても無視されていた。この変更によってそれを回避する。
